### PR TITLE
Add as you type check

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,13 +39,51 @@ clone_depth: 5
 
 # environment variables
 environment:
-  ARCH: 32
   matrix:
     - BUILDER: other
+      ARCH: 32
+      PYTHON_VERSION: 27
     - BUILDER: ghdl
-      # URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.31/Windows/ghdl-0.31-mcode-win32.zip
+      ARCH: 32
+      PYTHON_VERSION: 27
       URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
     - BUILDER: msim
+      ARCH: 32
+      PYTHON_VERSION: 27
+      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+    - BUILDER: other
+      ARCH: 64
+      PYTHON_VERSION: 27
+    - BUILDER: ghdl
+      ARCH: 64
+      PYTHON_VERSION: 27
+      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
+    - BUILDER: msim
+      ARCH: 64
+      PYTHON_VERSION: 27
+      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+
+    - BUILDER: other
+      ARCH: 32
+      PYTHON_VERSION: 35
+    - BUILDER: ghdl
+      ARCH: 32
+      PYTHON_VERSION: 35
+      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
+    - BUILDER: msim
+      ARCH: 32
+      PYTHON_VERSION: 35
+      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+    - BUILDER: other
+      ARCH: 64
+      PYTHON_VERSION: 35
+    - BUILDER: ghdl
+      ARCH: 64
+      PYTHON_VERSION: 35
+      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
+    - BUILDER: msim
+      ARCH: 64
+      PYTHON_VERSION: 35
       URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
 
 # # build cache to preserve files/folders between builds

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@
 # ---------------------------------#
 
 # version format
-version: 0.{build}
+version: '{build}'
 
 # branches to build
 branches:
@@ -39,52 +39,47 @@ clone_depth: 5
 
 # environment variables
 environment:
-  matrix:
-    - BUILDER: other
-      ARCH: 32
-      PYTHON_VERSION: 27
-    - BUILDER: ghdl
-      ARCH: 32
-      PYTHON_VERSION: 27
-      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
-    - BUILDER: msim
-      ARCH: 32
-      PYTHON_VERSION: 27
-      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
-    - BUILDER: other
-      ARCH: 64
-      PYTHON_VERSION: 27
-    - BUILDER: ghdl
-      ARCH: 64
-      PYTHON_VERSION: 27
-      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
-    - BUILDER: msim
-      ARCH: 64
-      PYTHON_VERSION: 27
-      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+  GHDL_URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
+  MSIM_URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
 
-    - BUILDER: other
-      ARCH: 32
-      PYTHON_VERSION: 35
-    - BUILDER: ghdl
-      ARCH: 32
-      PYTHON_VERSION: 35
-      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
-    - BUILDER: msim
-      ARCH: 32
-      PYTHON_VERSION: 35
-      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+  matrix:
+    # - BUILDER: other
+    #   ARCH: 32
+    #   PYTHON_VERSION: 27
+    # - BUILDER: ghdl
+    #   ARCH: 32
+    #   PYTHON_VERSION: 27
+    # - BUILDER: msim
+    #   ARCH: 32
+    #   PYTHON_VERSION: 27
     - BUILDER: other
       ARCH: 64
-      PYTHON_VERSION: 35
+      PYTHON_VERSION: 27
     - BUILDER: ghdl
       ARCH: 64
-      PYTHON_VERSION: 35
-      URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
+      PYTHON_VERSION: 27
     - BUILDER: msim
       ARCH: 64
+      PYTHON_VERSION: 27
+
+    # - BUILDER: other
+    #   ARCH: 32
+    #   PYTHON_VERSION: 35
+    # - BUILDER: ghdl
+    #   ARCH: 32
+    #   PYTHON_VERSION: 35
+    # - BUILDER: msim
+    #   ARCH: 32
+    #   PYTHON_VERSION: 35
+    - BUILDER: other
+      ARCH: 64
       PYTHON_VERSION: 35
-      URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+    - BUILDER: ghdl
+      ARCH: 64
+      PYTHON_VERSION: 35
+    - BUILDER: msim
+      ARCH: 64
+      PYTHON_VERSION: 35
 
 # # build cache to preserve files/folders between builds
 # cache:
@@ -99,6 +94,7 @@ install:
   - ps: . "$env:APPVEYOR_BUILD_FOLDER\\.ci\\scripts\\appveyor_env.ps1"
   - ps: . "$env:APPVEYOR_BUILD_FOLDER\\.ci\\scripts\\setup_env.ps1"
 
+  - python --version
   - if "%BUILDER%" == "msim" (python run_tests.py --msim -v)
   - if "%BUILDER%" == "ghdl" (python run_tests.py --ghdl -v)
   - if "%BUILDER%" == "other" (python run_tests.py --fallback --standalone -v)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,3 @@
-# Notes:
-#   - Minimal appveyor.yml file is an empty file. All sections are optional.
-#   - Indent each level of configuration with 2 spaces. Do not use tabs!
-#   - All section names are case-sensitive.
-#   - Section names should be unique on each level.
-
 ---
 # ---------------------------------#
 #       general configuration      #
@@ -20,6 +14,9 @@ branches:
 
 # Do not build on tags (GitHub only)
 skip_tags: true
+
+# Maximum number of concurrent jobs for the project
+max_jobs: 3
 
 # ---------------------------------#
 #    environment configuration    #
@@ -41,44 +38,20 @@ clone_depth: 5
 environment:
   GHDL_URL: http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip
   MSIM_URL: http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe
+  ARCH: 32
 
   matrix:
-    # - BUILDER: other
-    #   ARCH: 32
-    #   PYTHON_VERSION: 27
-    # - BUILDER: ghdl
-    #   ARCH: 32
-    #   PYTHON_VERSION: 27
-    # - BUILDER: msim
-    #   ARCH: 32
-    #   PYTHON_VERSION: 27
     - BUILDER: other
-      ARCH: 64
       PYTHON_VERSION: 27
     - BUILDER: ghdl
-      ARCH: 64
       PYTHON_VERSION: 27
     - BUILDER: msim
-      ARCH: 64
       PYTHON_VERSION: 27
-
-    # - BUILDER: other
-    #   ARCH: 32
-    #   PYTHON_VERSION: 35
-    # - BUILDER: ghdl
-    #   ARCH: 32
-    #   PYTHON_VERSION: 35
-    # - BUILDER: msim
-    #   ARCH: 32
-    #   PYTHON_VERSION: 35
     - BUILDER: other
-      ARCH: 64
       PYTHON_VERSION: 35
     - BUILDER: ghdl
-      ARCH: 64
       PYTHON_VERSION: 35
     - BUILDER: msim
-      ARCH: 64
       PYTHON_VERSION: 35
 
 # # build cache to preserve files/folders between builds

--- a/.ci/scripts/appveyor_env.ps1
+++ b/.ci/scripts/appveyor_env.ps1
@@ -33,7 +33,6 @@ if ($env:BUILDER -eq "msim") {
 }
 
 $env:CACHE_PATH="$env:CI_WORK_PATH\\cache"
-$env:ARCH="32"
 
 if (!(Test-Path "$env:CI_WORK_PATH")) {
     cmd /c "mkdir `"$env:CI_WORK_PATH`""

--- a/.ci/scripts/setup_env.ps1
+++ b/.ci/scripts/setup_env.ps1
@@ -17,10 +17,12 @@
 
 write-host "Configured builder is $env:BUILDER"
 
-$env:python_path = if ($env:arch -eq 32) { "C:\Python$env:PYTHON_VERSION" } else
-                                         { "C:\Python$env:PYTHON_VERSION-x64" }
+if ($env:ARCH -eq 32) {
+    $env:python_path = "C:\Python$env:PYTHON_VERSION"
+} else {
+    $env:python_path = "C:\Python$env:PYTHON_VERSION-x64"
+}
 
-write-host "Python selected is $env:python_path"
 $env:PATH="$env:python_path;$env:python_path\Scripts;$env:PATH"
 
 Start-Process "git" -RedirectStandardError git.log -Wait -NoNewWindow -ArgumentList `
@@ -55,4 +57,6 @@ if ("$env:BUILDER" -eq "msim") {
 
 pip install -U -e $env:APPVEYOR_BUILD_FOLDER
 if (!$?) {write-error "Something went wrong, exiting"; exit -1}
+
+write-host "Arch is $env:ARCH, Python selected is $env:python_path"
 

--- a/.ci/scripts/setup_env.ps1
+++ b/.ci/scripts/setup_env.ps1
@@ -17,11 +17,11 @@
 
 write-host "Configured builder is $env:BUILDER"
 
-$env:python = if ($env:arch -eq 32) { 'C:\Python27' } else
-                                    { 'C:\Python27-x64' }
+$env:python_path = if ($env:arch -eq 32) { "C:\Python$env:PYTHON_VERSION" } else
+                                         { "C:\Python$env:PYTHON_VERSION-x64" }
 
-write-host "Python selected is $env:python"
-$env:PATH="$env:PYTHON;$env:PYTHON\Scripts;$env:PATH"
+write-host "Python selected is $env:python_path"
+$env:PATH="$env:python_path;$env:python_path\Scripts;$env:PATH"
 
 Start-Process "git" -RedirectStandardError git.log -Wait -NoNewWindow -ArgumentList `
     "submodule update --init --recursive"

--- a/.ci/scripts/setup_ghdl.ps1
+++ b/.ci/scripts/setup_ghdl.ps1
@@ -20,15 +20,23 @@ write-host "Setting up GHDL..."
 $env:GHDL_PREFIX="$env:INSTALL_DIR\\lib"
 
 if (!(Test-Path "$env:CACHE_PATH\\ghdl.zip")) {
-    write-host "Downloading $env:BUILDER_NAME from $env:URL to $env:CACHE_PATH\\ghdl.zip"
-    if ($env:APPVEYOR -eq "True") {
-        "appveyor DownloadFile `"$env:URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
-        cmd /c "appveyor DownloadFile `"$env:URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
-    } else {
-        "curl -fsSL `"$env:URL`" --output `"$env:CACHE_PATH\\ghdl.zip`""
-        curl -fsSL "$env:URL" --output "$env:CACHE_PATH\\ghdl.zip"
-    }
-    if (!$?) {write-error "Something went wrong, exiting"; exit -1}
+    write-host "Downloading $env:BUILDER_NAME from $env:GHDL_URL to $env:CACHE_PATH\\ghdl.zip"
+
+    do {
+        if ($env:APPVEYOR -eq "True") {
+            "appveyor DownloadFile `"$env:GHDL_URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
+            cmd /c "appveyor DownloadFile `"$env:GHDL_URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
+        } else {
+            "curl -fsSL `"$env:GHDL_URL`" --output `"$env:CACHE_PATH\\ghdl.zip`""
+            curl -fsSL "$env:GHDL_URL" --output "$env:CACHE_PATH\\ghdl.zip"
+        }
+        $failed = 0
+        if (!$?) {
+            write-error "Something went wrong, retrying"
+            exit -1
+            $failed = 1
+        }
+    } while ($failed)
     write-host "Download finished"
 }
 

--- a/.ci/scripts/setup_msim.ps1
+++ b/.ci/scripts/setup_msim.ps1
@@ -16,10 +16,10 @@
 # along with HDL Code Checker.  If not, see <http://www.gnu.org/licenses/>.
 
 if (!(Test-Path "$env:CACHE_PATH\\modelsim.exe")) {
-    write-host "Downloading $env:BUILDER_NAME from $env:URL"
+    write-host "Downloading $env:BUILDER_NAME from $env:MSIM_URL"
     if ($env:APPVEYOR -eq "True") {
-        "appveyor DownloadFile `"$env:URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
-        cmd /c "appveyor DownloadFile `"$env:URL`" -filename `"$env:CACHE_PATH\\modelsim.exe`""
+        "appveyor DownloadFile `"$env:MSIM_URL`" -filename `"$env:CACHE_PATH\\ghdl.zip`""
+        cmd /c "appveyor DownloadFile `"$env:MSIM_URL`" -filename `"$env:CACHE_PATH\\modelsim.exe`""
     } else {
         cmd /c "copy `"e:\\ModelSimSetup-15.1.0.185-windows.exe`" `"$env:CACHE_PATH\\modelsim.exe`""
     }

--- a/.ci/scripts/test_ghdl.ps1
+++ b/.ci/scripts/test_ghdl.ps1
@@ -20,8 +20,8 @@
 
 $env:BUILDER_NAME="ghdl"
 $env:ARCH="32"
-# $env:URL="http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.31/Windows/ghdl-0.31-mcode-win32.zip"
-$env:URL="http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip"
+# $env:GHDL_URL="http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.31/Windows/ghdl-0.31-mcode-win32.zip"
+$env:GHDL_URL="http://pilotfiber.dl.sourceforge.net/project/ghdl-updates/Builds/ghdl-0.33/ghdl-0.33-win32.zip"
 # $env:INSTALL_DIR="$env:CI_WORK_PATH\\ghdl-0.31-mcode-win32"
 # $env:BUILDER_PATH="$env:INSTALL_DIR\\bin"
 

--- a/.ci/scripts/test_msim.ps1
+++ b/.ci/scripts/test_msim.ps1
@@ -24,7 +24,7 @@ if (!$?) {write-error "Something went wrong, exiting"; exit -1}
 $env:BUILDER_NAME="msim"
 $env:BUILDER_PATH="$env:CI_WORK_PATH\\modelsim_ase\\win32aloem"
 $env:ARCH="32"
-$env:URL="http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe"
+$env:GHDL_URL="http://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/ModelSimSetup-15.1.0.185-windows.exe"
 
 if ($env:APPVEYOR -ne "True") {
     write-host "Setting up virtualenv"

--- a/hdlcc/builders/fallback.py
+++ b/hdlcc/builders/fallback.py
@@ -40,7 +40,7 @@ class Fallback(BaseBuilder):
     def _checkEnvironment(self):
         return
 
-    def _buildSource(self, source, flags=None): # pragma: no cover
+    def _buildSource(self, path, library, flags=None): # pragma: no cover
         return [], []
 
     def _createLibrary(self, source): # pragma: no cover

--- a/hdlcc/builders/ghdl.py
+++ b/hdlcc/builders/ghdl.py
@@ -114,19 +114,19 @@ class GHDL(BaseBuilder):
         self._logger.debug("Builtin libraries found: %s",
                            " ".join(self._builtin_libraries))
 
-    def _getGhdlArgs(self, source, flags=None):
+    def _getGhdlArgs(self, path, library, flags=None):
         """
         Return the GHDL arguments that are common to most calls
         """
         cmd = ['-P%s' % self._target_folder,
-               '--work=%s' % source.library,
+               '--work=%s' % library,
                '--workdir=%s' % self._target_folder]
         if flags:
             cmd += flags
-        cmd += [source.filename]
+        cmd += [path]
         return cmd
 
-    def _importSource(self, source, flags=None):
+    def _importSource(self, path, library, flags=None):
         """
         Runs GHDL with import source switch
         """
@@ -136,28 +136,28 @@ class GHDL(BaseBuilder):
                 vhdl_std = [flag]
                 break
         self._logger.debug("Importing source with std '%s'", vhdl_std)
-        cmd = ['ghdl', '-i'] + self._getGhdlArgs(source, tuple(vhdl_std))
+        cmd = ['ghdl', '-i'] + self._getGhdlArgs(path, library, tuple(vhdl_std))
         return cmd
 
-    def _analyzeSource(self, source, flags=None):
+    def _analyzeSource(self, path, library, flags=None):
         """
         Runs GHDL with analyze source switch
         """
 
-        return ['ghdl', '-a'] + self._getGhdlArgs(source, flags)
+        return ['ghdl', '-a'] + self._getGhdlArgs(path, library, flags)
 
-    def _checkSyntax(self, source, flags=None):
+    def _checkSyntax(self, path, library, flags=None):
         """
         Runs GHDL with syntax check switch
         """
-        return ['ghdl', '-s'] + self._getGhdlArgs(source, flags)
+        return ['ghdl', '-s'] + self._getGhdlArgs(path, library, flags)
 
-    def _buildSource(self, source, flags=None):
-        self._importSource(source, flags)
+    def _buildSource(self, path, library, flags=None):
+        self._importSource(path, library, flags)
 
         stdout = []
-        for cmd in (self._analyzeSource(source, flags),
-                    self._checkSyntax(source, flags)):
+        for cmd in (self._analyzeSource(path, library, flags),
+                    self._checkSyntax(path, library, flags)):
             stdout += self._subprocessRunner(cmd)
 
         return stdout

--- a/hdlcc/builders/ghdl.py
+++ b/hdlcc/builders/ghdl.py
@@ -100,10 +100,10 @@ class GHDL(BaseBuilder):
         return self._builtin_libraries
 
     def _parseBuiltinLibraries(self):
-        "Discovers libraries that exist regardless before we do anything"
-        library_name_scan = None
+        """
+        Discovers libraries that exist regardless before we do anything
+        """
         for line in self._subprocessRunner(['ghdl', '--dispconfig']):
-            self._logger.info(repr(line))
             library_path_match = self._scan_library_paths(line)
             if library_path_match:
                 library_path = library_path_match.groupdict()['library_path']
@@ -115,7 +115,9 @@ class GHDL(BaseBuilder):
                            " ".join(self._builtin_libraries))
 
     def _getGhdlArgs(self, source, flags=None):
-        "Return the GHDL arguments that are common to most calls"
+        """
+        Return the GHDL arguments that are common to most calls
+        """
         cmd = ['-P%s' % self._target_folder,
                '--work=%s' % source.library,
                '--workdir=%s' % self._target_folder]
@@ -125,7 +127,9 @@ class GHDL(BaseBuilder):
         return cmd
 
     def _importSource(self, source, flags=None):
-        "Runs GHDL with import source switch"
+        """
+        Runs GHDL with import source switch
+        """
         vhdl_std = []
         for flag in flags:
             if flag.startswith('--std='):
@@ -136,11 +140,16 @@ class GHDL(BaseBuilder):
         return cmd
 
     def _analyzeSource(self, source, flags=None):
-        "Runs GHDL with analyze source switch"
+        """
+        Runs GHDL with analyze source switch
+        """
+
         return ['ghdl', '-a'] + self._getGhdlArgs(source, flags)
 
     def _checkSyntax(self, source, flags=None):
-        "Runs GHDL with syntax check switch"
+        """
+        Runs GHDL with syntax check switch
+        """
         return ['ghdl', '-s'] + self._getGhdlArgs(source, flags)
 
     def _buildSource(self, source, flags=None):

--- a/hdlcc/builders/xvhdl.py
+++ b/hdlcc/builders/xvhdl.py
@@ -124,14 +124,14 @@ class XVHDL(BaseBuilder):
                  for x in self._added_libraries])
             fd.write(content)
 
-    def _buildSource(self, source, flags=None):
+    def _buildSource(self, path, library, flags=None):
         cmd = ['xvhdl',
                '--nolog',
                '--verbose', '0',
                '--initfile', p.abspath(self._xvhdlini),
-               '--work', source.library]
+               '--work', library]
         cmd += flags
-        cmd += [source.filename]
+        cmd += [path]
         return self._subprocessRunner(cmd)
 
     def _searchForRebuilds(self, line):

--- a/hdlcc/handlers.py
+++ b/hdlcc/handlers.py
@@ -161,7 +161,6 @@ def getMessagesByPath():
     project_file = bottle.request.forms.get('project_file')
     path = bottle.request.forms.get('path')
     content = bottle.request.forms.get('content', None)
-    _logger.fatal(content)
 
     _logger.debug("Getting messages for '%s', '%s', %s", project_file, path,
                   "no content" if content is None else "with content")

--- a/hdlcc/handlers.py
+++ b/hdlcc/handlers.py
@@ -141,18 +141,22 @@ def getMessagesByPath():
     """
     Get messages for a given projec_file/path pair
     """
-    project_file = bottle.request.forms.get('project_file')
-    path = bottle.request.forms.get('path')
-    _logger.debug("Getting messages for '%s', '%s'", project_file, path)
+    try:
+        project_file = bottle.request.forms.get('project_file')
+        path = bottle.request.forms.get('path')
+        _logger.debug("Getting messages for '%s', '%s'", project_file, path)
 
-    server = _getServerByProjectFile(project_file)
-    response = {}
-    response['messages'] = []
+        server = _getServerByProjectFile(project_file)
+        response = {}
+        response['messages'] = []
 
-    for msg in server.getMessagesByPath(path):
-        response['messages'] += [msg]
+        for msg in server.getMessagesByPath(path):
+            response['messages'] += [msg]
 
-    return response
+        return response
+    except:
+        _logger.exception("Caught exception while getting messages by path")
+        raise
 
 @app.post('/get_ui_messages')
 def getUiMessages():

--- a/hdlcc/hdlcc_base.py
+++ b/hdlcc/hdlcc_base.py
@@ -486,9 +486,12 @@ class HdlCodeCheckerBase(object):
         else:
             assert False, "Unknown file type %s" % file_type
 
-        _, tmp_filename = tempfile.mkstemp(suffix=tmp_extension)
+        tmp_fd, tmp_filename = tempfile.mkstemp(suffix=tmp_extension)
         try:
-            open(tmp_filename, 'w').write(content)
+            fd = open(tmp_filename, 'w')
+            fd.write(content)
+            fd.close()
+            os.close(tmp_fd)
 
             # Try to find a source with this path so we can copy most of its
             # properties set in the configuration process and change only
@@ -506,10 +509,11 @@ class HdlCodeCheckerBase(object):
                 if not message['filename'] or samefile(message['filename'],
                                                        tmp_filename):
                     message['filename'] = path
-
                 messages.append(message)
+
         finally:
             os.remove(tmp_filename)
+
         return messages
 
     def getSources(self):

--- a/hdlcc/hdlcc_base.py
+++ b/hdlcc/hdlcc_base.py
@@ -274,7 +274,7 @@ class HdlCodeCheckerBase(object):
         # that the editor is unaware of (Vivado maybe?) To cope with
         # this, we'll check if the newest modification time of the build
         # sequence hasn't changed since we cached the build sequence
-        key = str(source.filename)
+        key = str(source.real_filename)
         if key not in self._build_sequence_cache:
             build_sequence = []
             self._getBuildSequence(source, build_sequence)
@@ -470,7 +470,8 @@ class HdlCodeCheckerBase(object):
 
     def getMessagesWithText(self, path, content):
         """
-        Get
+        Gets messages from a given path with a different content, for
+        the cases when the buffer content has been modified
         """
         self._logger.debug("Getting messages for '%s' with content", path)
 
@@ -503,9 +504,11 @@ class HdlCodeCheckerBase(object):
                 original_source, remarks = self._getSourceByPath(path)
                 state = original_source.getState()
                 source = cls.recoverFromState(state)
+                source.real_filename = source.filename
                 source.filename = tmp_filename
             except KeyError:
                 source = cls(tmp_filename)
+
 
             messages = []
             for message in self.getMessagesBySource(source):

--- a/hdlcc/parsers/base_parser.py
+++ b/hdlcc/parsers/base_parser.py
@@ -34,6 +34,13 @@ class BaseSourceFile(object):  # pylint:disable=too-many-instance-attributes
 
     __metaclass__ = abc.ABCMeta
 
+    @abc.abstractproperty
+    def _comment(self):
+        """
+        Should return a regex object that matches a comment (or comments)
+        used by the language
+        """
+
     def __init__(self, filename, library='work', flags=None):
         self.filename = p.normpath(filename)
         self.library = library
@@ -142,16 +149,12 @@ class BaseSourceFile(object):  # pylint:disable=too-many-instance-attributes
         self._buffer_content = content
         self._buffer_time = time.time()
 
-    def getBufferContent(self):
-        return self._buffer_content
-
     def hasBufferContent(self):
         return self._buffer_content is not None
 
     def dumpBufferContentToFile(self):
         buffer_dump_path = p.join(p.dirname(self.filename), '.dump_' +
                                   p.basename(self.filename))
-        #  assert not p.exists(buffer_dump_path)
         open(buffer_dump_path, 'w').write(self._buffer_content)
         return buffer_dump_path
 

--- a/hdlcc/parsers/base_parser.py
+++ b/hdlcc/parsers/base_parser.py
@@ -33,8 +33,10 @@ class BaseSourceFile(object):  # pylint:disable=too-many-instance-attributes
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, filename, library='work', flags=None):
+    def __init__(self, filename, library='work', flags=None,
+                 real_filename=None):
         self.filename = p.normpath(filename)
+        self._real_filename = None
         self.library = library
         self.flags = flags if flags is not None else []
         self._cache = {}
@@ -43,6 +45,16 @@ class BaseSourceFile(object):  # pylint:disable=too-many-instance-attributes
         self.filetype = getFileType(self.filename)
 
         self.abspath = p.abspath(filename)
+
+    @property
+    def real_filename(self):
+        if self._real_filename is None:
+            return self.filename
+        return self._real_filename
+
+    @real_filename.setter
+    def real_filename(self, value):
+        self._real_filename = value
 
     def getState(self):
         """

--- a/hdlcc/parsers/verilog_parser.py
+++ b/hdlcc/parsers/verilog_parser.py
@@ -30,30 +30,31 @@ _DESIGN_UNIT_SCANNER = re.compile('|'.join([
     ]), flags=re.S)
 
 class VerilogParser(BaseSourceFile):
-    """Parses and stores information about a source file such as
-    design units it depends on and design units it provides"""
+    """
+    Parses and stores information about a Verilog or SystemVerilog
+    source file
+    """
+
+    _comment = re.compile(r'/\*.*\*/|//[^(\r\n?|\n)]*', flags=re.S)
 
     def _getSourceContent(self):
-        """Replace everything from comment ('--') until a line break
-        and converts to lowercase"""
         # Remove multiline comments
-        lines = re.sub(r'/\*.*\*/|//[^(\r\n?|\n)]*', '',
-                       open(self.filename, 'r').read(), flags=re.S)
+        content = open(self.filename, mode='rb').read().decode(errors='ignore')
+        lines = self._comment.sub('', content)
         return re.sub(r'\r\n?|\n', ' ', lines, flags=re.S)
 
     def _iterDesignUnitMatches(self):
-        """Iterates over the matches of _DESIGN_UNIT_SCANNER against
-        source's lines"""
+        """
+        Iterates over the matches of _DESIGN_UNIT_SCANNER against
+        source's lines
+        """
         for match in _DESIGN_UNIT_SCANNER.finditer(self.getSourceContent()):
             yield match.groupdict()
 
     def _getDependencies(self):
-        """Parses the source and returns a list of dictionaries that
-        describe its dependencies"""
         return []
 
     def _getDesignUnits(self):
-        "Parses the source file to find design units and dependencies"
         design_units = []
 
         for match in self._iterDesignUnitMatches():
@@ -72,6 +73,4 @@ class VerilogParser(BaseSourceFile):
 
     def _getLibraries(self):
         return []
-
-
 

--- a/hdlcc/parsers/vhdl_parser.py
+++ b/hdlcc/parsers/vhdl_parser.py
@@ -37,7 +37,7 @@ _ADDITIONAL_DEPS_SCANNER = re.compile('|'.join([
     r"\bpackage\s+body\s+(?P<package_body_name>\w+)\s+is\b",
     r"\bcomponent\s+(?P<component_name>\w+)\s+(generic|port|is)\b"]), flags=re.M)
 
-_SUB_COMMENTS = re.compile(r"\s*--[^\n]*", flags=re.S).sub
+_SUB_COMMENTS = re.compile(r"--[^\n\r]*", flags=re.S).sub
 
 class VhdlParser(BaseSourceFile):
     """

--- a/hdlcc/parsers/vhdl_parser.py
+++ b/hdlcc/parsers/vhdl_parser.py
@@ -37,7 +37,6 @@ _ADDITIONAL_DEPS_SCANNER = re.compile('|'.join([
     r"\bpackage\s+body\s+(?P<package_body_name>\w+)\s+is\b",
     r"\bcomponent\s+(?P<component_name>\w+)\s+(generic|port|is)\b"]), flags=re.M)
 
-_SUB_COMMENTS = re.compile(r"--[^\n\r]*", flags=re.S).sub
 
 class VhdlParser(BaseSourceFile):
     """
@@ -45,13 +44,15 @@ class VhdlParser(BaseSourceFile):
     units it depends on and design units it provides
     """
 
+    _comment = re.compile(r"--[^\n\r]*", flags=re.S)
+
     def _getSourceContent(self):
         """
         Replace everything from comment ('--') until a line break and
         converts to lowercase
         """
         content = open(self.filename, mode='rb').read().decode(errors='ignore')
-        return _SUB_COMMENTS('', content).lower()
+        return self._comment.sub('', content).lower()
 
     def _iterDesignUnitMatches(self):
         """

--- a/hdlcc/tests/test_builders.py
+++ b/hdlcc/tests/test_builders.py
@@ -21,9 +21,10 @@ import logging
 import os
 import os.path as p
 import shutil
-import mock
 from nose2.tools import such
 from nose2.tools.params import params
+
+import mock
 
 import hdlcc.builders
 import hdlcc.utils as utils

--- a/hdlcc/tests/test_hdlcc_base.py
+++ b/hdlcc/tests/test_hdlcc_base.py
@@ -64,7 +64,7 @@ with such.A("hdlcc project") as it:
         _logger.info("Builder name: %s", it.BUILDER_NAME)
         _logger.info("Builder path: %s", it.BUILDER_PATH)
 
-        it._patch = mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+        it._patch = mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
         it._patch.start()
 
     @it.has_teardown

--- a/hdlcc/tests/test_hdlcc_base.py
+++ b/hdlcc/tests/test_hdlcc_base.py
@@ -441,13 +441,9 @@ with such.A("hdlcc project") as it:
             )
 
         project = StandaloneProjectBuilder()
-        project._config._sources = {}
-        for source in sources:
-            project._config._sources[source.filename] = source
-
         path = sources[0].filename
         it.assertEquals(
-            project._getBuilderMessages(path),
+            project.getMessagesByPath(path),
             [{'checker'        : 'hdlcc',
               'line_number'    : '',
               'column'         : '',
@@ -456,7 +452,6 @@ with such.A("hdlcc project") as it:
               'error_type'     : 'W',
               'error_message'  : 'Path "%s" not found in project file' %
                                  p.abspath(path)}])
-
 
     @it.should("warn when unable to recreate a builder described in cache")
     @mock.patch('hdlcc.builders.getBuilderByName', new=lambda name: FailingBuilder)

--- a/hdlcc/tests/test_hdlcc_server.py
+++ b/hdlcc/tests/test_hdlcc_server.py
@@ -114,7 +114,7 @@ with such.A("hdlcc server") as it:
         utils.terminateProcess(it._server.pid)
 
     @it.should("shutdown the server when requested")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         startCodeCheckerServer()
         # Ensure the server is active

--- a/hdlcc/tests/test_persistence.py
+++ b/hdlcc/tests/test_persistence.py
@@ -55,7 +55,7 @@ class StandaloneProjectBuilder(hdlcc.HdlCodeCheckerBase):
         self._ui_handler.error(message)
         self._msg_queue.put(('error', message))
 
-with such.A("hdlcc project with persistency") as it:
+with such.A("hdlcc project with persistence") as it:
 
     @it.has_setup
     def setup():

--- a/hdlcc/tests/test_persistence.py
+++ b/hdlcc/tests/test_persistence.py
@@ -119,7 +119,7 @@ with such.A("hdlcc project with persistence") as it:
             if p.exists(cache_fname):
                 os.remove(cache_fname)
 
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def _buildWithoutCache():
         it.project = StandaloneProjectBuilder(it.PROJECT_FILE)
 
@@ -135,7 +135,7 @@ with such.A("hdlcc project with persistence") as it:
                        "Project shouldn't have recovered from cache. "
                        "Messages found:\n%s" % "\n".join(messages))
 
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def _buildWithCache():
         del it.project
 
@@ -190,7 +190,7 @@ with such.A("hdlcc project with persistence") as it:
             _buildWithCache()
 
         @it.should('build without cache if cache is invalid')
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+        @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
         def test_003():
             if not it.BUILDER_NAME:
                 _logger.info("Skipping test, it requires a builder")
@@ -256,7 +256,7 @@ with such.A("hdlcc project with persistence") as it:
             utils.cleanProjectCache(it.PROJECT_FILE)
 
         @it.should('use fallback builder if recovering cache failed')
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+        @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
         def test_001():
             if not it.BUILDER_NAME:
                 _logger.info("Skipping test, it requires a builder")

--- a/hdlcc/tests/test_server_handlers.py
+++ b/hdlcc/tests/test_server_handlers.py
@@ -51,10 +51,19 @@ with such.A("hdlcc bottle app") as it:
     def setup():
         it.BUILDER_NAME = os.environ.get('BUILDER_NAME', None)
         it.BUILDER_PATH = os.environ.get('BUILDER_PATH', None)
+        _logger.info("Builder name: %s", it.BUILDER_NAME)
+        _logger.info("Builder path: %s", it.BUILDER_PATH)
         if it.BUILDER_NAME:
             it.PROJECT_FILE = p.join(VIM_HDL_EXAMPLES, it.BUILDER_NAME + '.prj')
         else:
             it.PROJECT_FILE = None
+
+        if it.BUILDER_PATH:
+            it.patch = mock.patch.dict(
+                'os.environ',
+                {'PATH' : os.pathsep.join([it.BUILDER_PATH, os.environ['PATH']])})
+            it.patch.start()
+        it.app = TestApp(handlers.app)
 
     @it.has_teardown
     def teardown():
@@ -67,323 +76,286 @@ with such.A("hdlcc bottle app") as it:
         if p.exists('.xvhdl.init'):
             os.remove('.xvhdl.init')
 
-    with it.having("no PID attachment"):
-        @it.has_setup
-        def setup():
-            _logger.info("Builder name: %s", it.BUILDER_NAME)
-            _logger.info("Builder path: %s", it.BUILDER_PATH)
-            if it.BUILDER_PATH:
-                it.patch = mock.patch.dict(
-                    'os.environ',
-                    {'PATH' : os.pathsep.join([it.BUILDER_PATH, os.environ['PATH']])})
-                it.patch.start()
-            it.app = TestApp(handlers.app)
+        if it.BUILDER_PATH:
+            it.patch.stop()
 
-        @it.has_teardown
-        def teardown():
-            if it.BUILDER_PATH:
-                it.patch.stop()
+    @it.should("get diagnose info without any project")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        reply = it.app.post_json('/get_diagnose_info')
+        it.assertItemsEqual(
+            reply.json['info'],
+            [u'hdlcc version: %s' % hdlcc.__version__,
+             u'Server PID: %d' % os.getpid()])
 
-        @it.should("get diagnose info without any project")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            reply = it.app.post_json('/get_diagnose_info')
+    @it.should("get diagnose info with an existing project file")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        reply = it.app.post(
+            '/get_diagnose_info',
+            {'project_file' : it.PROJECT_FILE})
+
+        _logger.info("Reply is %s", reply.json['info'])
+
+        if it.BUILDER_NAME:
+            it.assertItemsEqual(
+                reply.json['info'],
+                [u'hdlcc version: %s' % hdlcc.__version__,
+                 u'Server PID: %d' % os.getpid(),
+                 u'Builder: %s' % it.BUILDER_NAME])
+        else:
             it.assertItemsEqual(
                 reply.json['info'],
                 [u'hdlcc version: %s' % hdlcc.__version__,
                  u'Server PID: %d' % os.getpid()])
 
-        @it.should("get diagnose info with an existing project file")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
+    @it.should("get diagnose info while still not found out the builder name")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        def _getServerByProjectFile(_):
+            server = mock.MagicMock()
+            server.builder = None
+            return server
+        with mock.patch('hdlcc.handlers._getServerByProjectFile',
+                        _getServerByProjectFile):
             reply = it.app.post(
                 '/get_diagnose_info',
                 {'project_file' : it.PROJECT_FILE})
-
-            _logger.info("Reply is %s", reply.json['info'])
-
-            if it.BUILDER_NAME:
+            if it.BUILDER_NAME in ('msim', 'ghdl', 'xvhdl'):
                 it.assertItemsEqual(
                     reply.json['info'],
                     [u'hdlcc version: %s' % hdlcc.__version__,
                      u'Server PID: %d' % os.getpid(),
-                     u'Builder: %s' % it.BUILDER_NAME])
+                     u'Builder: <unknown> (config file parsing is underway)'])
             else:
                 it.assertItemsEqual(
                     reply.json['info'],
                     [u'hdlcc version: %s' % hdlcc.__version__,
                      u'Server PID: %d' % os.getpid()])
 
-        @it.should("get diagnose info while still not found out the builder name")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            def _getServerByProjectFile(_):
-                server = mock.MagicMock()
-                server.builder = None
-                return server
-            with mock.patch('hdlcc.handlers._getServerByProjectFile',
-                            _getServerByProjectFile):
-                reply = it.app.post(
-                    '/get_diagnose_info',
-                    {'project_file' : it.PROJECT_FILE})
-                if it.BUILDER_NAME in ('msim', 'ghdl', 'xvhdl'):
-                    it.assertItemsEqual(
-                        reply.json['info'],
-                        [u'hdlcc version: %s' % hdlcc.__version__,
-                         u'Server PID: %d' % os.getpid(),
-                         u'Builder: <unknown> (config file parsing is underway)'])
-                else:
-                    it.assertItemsEqual(
-                        reply.json['info'],
-                        [u'hdlcc version: %s' % hdlcc.__version__,
-                         u'Server PID: %d' % os.getpid()])
+    @it.should("get diagnose info with a non existing project file")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        reply = it.app.post(
+            '/get_diagnose_info',
+            {'project_file' : 'some_project'})
 
-        @it.should("get diagnose info with a non existing project file")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            reply = it.app.post(
-                '/get_diagnose_info',
-                {'project_file' : 'some_project'})
+        _logger.info("Reply is %s", reply.json['info'])
+        it.assertItemsEqual(
+            reply.json['info'],
+            [u'hdlcc version: %s' % hdlcc.__version__,
+             u'Server PID: %d' % os.getpid()])
 
-            _logger.info("Reply is %s", reply.json['info'])
-            it.assertItemsEqual(
-                reply.json['info'],
-                [u'hdlcc version: %s' % hdlcc.__version__,
-                 u'Server PID: %d' % os.getpid()])
+    @it.should("rebuild the project with directory cleanup")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        if not it.BUILDER_NAME:
+            _logger.info("Test requires a builder")
+            return
+        # The main reason to rebuild is when the project data is corrupt
+        # Test is as follows:
+        # 1) Check that a file builds OK
+        # 2) Erase the target folder.
+        # 3) Check the file fails to build
+        # 4) Rebuild the project
+        # 5) Check the file builds OK again and returns the same set of
+        #    messages
 
-        @it.should("rebuild the project with directory cleanup")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            if not it.BUILDER_NAME:
-                _logger.info("Test requires a builder")
-                return
-            # The main reason to rebuild is when the project data is corrupt
-            # Test is as follows:
-            # 1) Check that a file builds OK
-            # 2) Erase the target folder.
-            # 3) Check the file fails to build
-            # 4) Rebuild the project
-            # 5) Check the file builds OK again and returns the same set of
-            #    messages
+        def step_01_check_file_builds_ok():
+            data = {
+                'project_file' : it.PROJECT_FILE,
+                'path'         : p.join(
+                    VIM_HDL_EXAMPLES, 'another_library', 'foo.vhd')}
 
-            def step_01_check_file_builds_ok():
-                data = {
-                    'project_file' : it.PROJECT_FILE,
-                    'path'         : p.join(
-                        VIM_HDL_EXAMPLES, 'another_library', 'foo.vhd')}
+            ui_reply = it.app.post('/get_ui_messages', data)
+            reply = it.app.post('/get_messages_by_path', data)
 
-                ui_reply = it.app.post('/get_ui_messages', data)
-                reply = it.app.post('/get_messages_by_path', data)
+            return reply.json['messages'] + ui_reply.json['ui_messages']
 
-                return reply.json['messages'] + ui_reply.json['ui_messages']
+        def step_02_erase_target_folder():
+            target_folder = p.join(VIM_HDL_EXAMPLES, '.build')
+            it.assertTrue(
+                p.exists(target_folder),
+                "Target folder '%s' doesn't exists" % target_folder)
+            shutil.rmtree(target_folder)
+            it.assertFalse(
+                p.exists(target_folder),
+                "Target folder '%s' still exists!" % target_folder)
 
-            def step_02_erase_target_folder():
-                target_folder = p.join(VIM_HDL_EXAMPLES, '.build')
-                it.assertTrue(
-                    p.exists(target_folder),
-                    "Target folder '%s' doesn't exists" % target_folder)
-                shutil.rmtree(target_folder)
-                it.assertFalse(
-                    p.exists(target_folder),
-                    "Target folder '%s' still exists!" % target_folder)
-
-            def step_03_check_build_fails(ref_msgs):
-                step_03_msgs = step_01_check_file_builds_ok()
-                if step_03_msgs:
-                    _logger.info("Step 03 messages:")
-                    for msg in step_03_msgs:
-                        _logger.info(msg)
-                else:
-                    _logger.info("Step 03 generated no messages")
-
-                it.assertNotEquals(step_01_msgs, step_03_msgs)
-
-            def step_04_rebuild_project():
-                data = {'project_file' : it.PROJECT_FILE}
-                it.app.post('/rebuild_project', data)
-                data = {
-                    'project_file' : it.PROJECT_FILE,
-                    'path'         : p.join(
-                        VIM_HDL_EXAMPLES, 'basic_library', 'clock_divider.vhd')}
-
-            def step_05_check_messages_are_the_same(msgs):
-                step_05_msgs = step_01_check_file_builds_ok()
-                if step_05_msgs:
-                    _logger.info("Step 05 messages:")
-                    for msg in step_05_msgs:
-                        _logger.info(msg)
-                else:
-                    _logger.info("Step 05 generated no messages")
-
-                it.assertEquals(msgs, step_05_msgs)
-
-            _logger.info("Step 01")
-            step_01_msgs = step_01_check_file_builds_ok()
-            if step_01_msgs:
-                _logger.info("Step 01 messages:")
-            else:
-                _logger.info("Step 01 generated no messages")
-
-            for msg in step_01_msgs:
-                _logger.info(msg)
-                it.assertNotEquals(
-                    msg.get('error_type', None), 'E',
-                    "No errors should be found at this point")
-
-            _logger.info("Step 02")
-            step_02_erase_target_folder()
-
-            _logger.info("Step 03")
-            step_03_check_build_fails(step_01_msgs)
-
-            _logger.info("Step 04")
-            step_04_rebuild_project()
-
-            _logger.info("Step 05")
-            step_05_check_messages_are_the_same(step_01_msgs)
-
-        @it.should("rebuild the project without directory cleanup")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
-                _logger.info("Test requires a builder, except fallback")
-                return
-            # If the user doesn't knows if the project data is corrupt, he/she
-            # should be able to rebuild even if everything is OK.
-            # Test is as follows:
-            # 1) Check that a file builds OK
-            # 2) Rebuild the project
-            # 3) Check the file builds OK again and returns the same set of
-            #    messages
-
-            def step_01_check_file_builds_ok():
-                data = {
-                    'project_file' : it.PROJECT_FILE,
-                    'path'         : p.join(
-                        VIM_HDL_EXAMPLES, 'another_library', 'foo.vhd')}
-                _logger.info("Waiting for any previous process to finish")
-
-                ui_reply = it.app.post('/get_ui_messages', data)
-                reply = it.app.post('/get_messages_by_path', data)
-
-                return reply.json['messages'] + ui_reply.json['ui_messages']
-
-            def step_02_rebuild_project():
-                data = {'project_file' : it.PROJECT_FILE}
-                it.app.post('/rebuild_project', data)
-                data = {
-                    'project_file' : it.PROJECT_FILE,
-                    'path'         : p.join(
-                        VIM_HDL_EXAMPLES, 'basic_library', 'clock_divider.vhd')}
-
-            def step_03_check_messages_are_the_same(msgs):
-                step_03_msgs = step_01_check_file_builds_ok()
-                if step_03_msgs:
-                    _logger.info("Step 03 messages:")
-                    for msg in step_03_msgs:
-                        _logger.info(msg)
-                else:
-                    _logger.info("Step 03 generated no messages")
-
-                it.assertEquals(msgs, step_03_msgs)
-
-            _logger.info("Step 01")
-            step_01_msgs = step_01_check_file_builds_ok()
-            if step_01_msgs:
-                _logger.info("Step 01 messages:")
-                for msg in step_01_msgs:
+        def step_03_check_build_fails(ref_msgs):
+            step_03_msgs = step_01_check_file_builds_ok()
+            if step_03_msgs:
+                _logger.info("Step 03 messages:")
+                for msg in step_03_msgs:
                     _logger.info(msg)
             else:
-                _logger.info("Step 01 generated no messages")
+                _logger.info("Step 03 generated no messages")
 
-            _logger.info("Step 02")
-            step_02_rebuild_project()
+            it.assertNotEquals(step_01_msgs, step_03_msgs)
 
-            _logger.info("Step 03")
-            step_03_check_messages_are_the_same(step_01_msgs)
+        def step_04_rebuild_project():
+            data = {'project_file' : it.PROJECT_FILE}
+            it.app.post('/rebuild_project', data)
+            data = {
+                'project_file' : it.PROJECT_FILE,
+                'path'         : p.join(
+                    VIM_HDL_EXAMPLES, 'basic_library', 'clock_divider.vhd')}
 
-        @it.should("shutdown the server when requested")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            # Ensure the server is active
-            reply = it.app.post('/get_diagnose_info',
-                                {'project_file' : 'some_project'})
-            it.assertEqual(reply.status, '200 OK')
-
-            # Send a request to shutdown the server and check if it
-            # calls the terminate process method
-            pids = []
-            def terminateProcess(pid):
-                _logger.info("Terminating PID %d", pid)
-                pids.append(pid)
-
-            with mock.patch('hdlcc.utils.terminateProcess', terminateProcess):
-                reply = it.app.post('/shutdown')
-                it.assertEqual(pids, [os.getpid(),])
-
-    with it.having("GRLIB as reference library"):
-        @it.has_setup
-        def setup():
-            it.BUILDER_NAME = os.environ.get('BUILDER_NAME', None)
-            it.BUILDER_PATH = os.environ.get('BUILDER_PATH', None)
-            if it.BUILDER_NAME:
-                it.PROJECT_FILE = p.join(VIM_HDL_EXAMPLES, it.BUILDER_NAME + '.prj')
+        def step_05_check_messages_are_the_same(msgs):
+            step_05_msgs = step_01_check_file_builds_ok()
+            if step_05_msgs:
+                _logger.info("Step 05 messages:")
+                for msg in step_05_msgs:
+                    _logger.info(msg)
             else:
-                it.PROJECT_FILE = None
+                _logger.info("Step 05 generated no messages")
 
-            cache = p.join(VIM_HDL_EXAMPLES, '.hdlcc')
+            it.assertEquals(msgs, step_05_msgs)
 
-            if p.exists(cache):
-                shutil.rmtree(cache)
+        _logger.info("Step 01")
+        step_01_msgs = step_01_check_file_builds_ok()
+        if step_01_msgs:
+            _logger.info("Step 01 messages:")
+        else:
+            _logger.info("Step 01 generated no messages")
 
-            it.test_file = p.join(VIM_HDL_EXAMPLES, 'another_library',
-                                  'foo.vhd')
+        for msg in step_01_msgs:
+            _logger.info(msg)
+            it.assertNotEquals(
+                msg.get('error_type', None), 'E',
+                "No errors should be found at this point")
 
-            if it.BUILDER_PATH:
-                it.patch = mock.patch.dict(
-                    'os.environ',
-                    {'PATH' : os.pathsep.join([it.BUILDER_PATH, os.environ['PATH']])})
-                it.patch.start()
+        _logger.info("Step 02")
+        step_02_erase_target_folder()
 
-            #  startCodeCheckerServer()
+        _logger.info("Step 03")
+        step_03_check_build_fails(step_01_msgs)
 
-        @it.has_teardown
-        def teardown():
-            if it.BUILDER_PATH:
-                it.patch.stop()
+        _logger.info("Step 04")
+        step_04_rebuild_project()
 
-            cache = p.join(VIM_HDL_EXAMPLES, '.hdlcc')
-            if p.exists(cache):
-                shutil.rmtree(cache)
+        _logger.info("Step 05")
+        step_05_check_messages_are_the_same(step_01_msgs)
 
-        @it.should("handle buffer visits without crashing")
-        @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
-        def test():
-            if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
-                _logger.info("Test requires a builder, except fallback")
-                return
+    @it.should("rebuild the project without directory cleanup")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
+            _logger.info("Test requires a builder, except fallback")
+            return
+        # If the user doesn't knows if the project data is corrupt, he/she
+        # should be able to rebuild even if everything is OK.
+        # Test is as follows:
+        # 1) Check that a file builds OK
+        # 2) Rebuild the project
+        # 3) Check the file builds OK again and returns the same set of
+        #    messages
 
-            def build_without_buffer_visit():
-                data = {'project_file' : it.PROJECT_FILE,
-                        'path'         : it.test_file}
+        def step_01_check_file_builds_ok():
+            data = {
+                'project_file' : it.PROJECT_FILE,
+                'path'         : p.join(
+                    VIM_HDL_EXAMPLES, 'another_library', 'foo.vhd')}
+            _logger.info("Waiting for any previous process to finish")
 
-                _ = it.app.post('/get_messages_by_path', data)
+            ui_reply = it.app.post('/get_ui_messages', data)
+            reply = it.app.post('/get_messages_by_path', data)
 
-            def build_with_buffer_visit():
-                data = {'project_file' : it.PROJECT_FILE,
-                        'path'         : it.test_file}
+            return reply.json['messages'] + ui_reply.json['ui_messages']
 
-                _ = it.app.post('/on_buffer_visit', data)
+        def step_02_rebuild_project():
+            data = {'project_file' : it.PROJECT_FILE}
+            it.app.post('/rebuild_project', data)
+            data = {
+                'project_file' : it.PROJECT_FILE,
+                'path'         : p.join(
+                    VIM_HDL_EXAMPLES, 'basic_library', 'clock_divider.vhd')}
 
-            def build_with_buffer_leave():
-                data = {'project_file' : it.PROJECT_FILE,
-                        'path'         : it.test_file}
+        def step_03_check_messages_are_the_same(msgs):
+            step_03_msgs = step_01_check_file_builds_ok()
+            if step_03_msgs:
+                _logger.info("Step 03 messages:")
+                for msg in step_03_msgs:
+                    _logger.info(msg)
+            else:
+                _logger.info("Step 03 generated no messages")
 
-                _ = it.app.post('/on_buffer_leave', data)
+            it.assertEquals(msgs, step_03_msgs)
 
-            build_without_buffer_visit()
-            build_with_buffer_leave()
-            build_with_buffer_visit()
+        _logger.info("Step 01")
+        step_01_msgs = step_01_check_file_builds_ok()
+        if step_01_msgs:
+            _logger.info("Step 01 messages:")
+            for msg in step_01_msgs:
+                _logger.info(msg)
+        else:
+            _logger.info("Step 01 generated no messages")
+
+        _logger.info("Step 02")
+        step_02_rebuild_project()
+
+        _logger.info("Step 03")
+        step_03_check_messages_are_the_same(step_01_msgs)
+
+    @it.should("shutdown the server when requested")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        # Ensure the server is active
+        reply = it.app.post('/get_diagnose_info',
+                            {'project_file' : 'some_project'})
+        it.assertEqual(reply.status, '200 OK')
+
+        # Send a request to shutdown the server and check if it
+        # calls the terminate process method
+        pids = []
+        def terminateProcess(pid):
+            _logger.info("Terminating PID %d", pid)
+            pids.append(pid)
+
+        with mock.patch('hdlcc.utils.terminateProcess', terminateProcess):
+            reply = it.app.post('/shutdown')
+            it.assertEqual(pids, [os.getpid(),])
+
+    @it.has_teardown
+    def teardown():
+        if it.BUILDER_PATH:
+            it.patch.stop()
+
+        cache = p.join(VIM_HDL_EXAMPLES, '.hdlcc')
+        if p.exists(cache):
+            shutil.rmtree(cache)
+
+    @it.should("handle buffer visits without crashing")
+    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    def test():
+        if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
+            _logger.info("Test requires a builder, except fallback")
+            return
+
+        test_file = p.join(VIM_HDL_EXAMPLES, 'another_library', 'foo.vhd')
+
+
+        def build_without_buffer_visit():
+            data = {'project_file' : it.PROJECT_FILE,
+                    'path'         : test_file}
+
+            _ = it.app.post('/get_messages_by_path', data)
+
+        def build_with_buffer_visit():
+            data = {'project_file' : it.PROJECT_FILE,
+                    'path'         : test_file}
+
+            _ = it.app.post('/on_buffer_visit', data)
+
+        def build_with_buffer_leave():
+            data = {'project_file' : it.PROJECT_FILE,
+                    'path'         : test_file}
+
+            _ = it.app.post('/on_buffer_leave', data)
+
+        build_without_buffer_visit()
+        build_with_buffer_leave()
+        build_with_buffer_visit()
 
 it.createTests(globals())
 

--- a/hdlcc/tests/test_server_handlers.py
+++ b/hdlcc/tests/test_server_handlers.py
@@ -80,7 +80,7 @@ with such.A("hdlcc bottle app") as it:
             it.patch.stop()
 
     @it.should("get diagnose info without any project")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         reply = it.app.post_json('/get_diagnose_info')
         it.assertItemsEqual(
@@ -89,7 +89,7 @@ with such.A("hdlcc bottle app") as it:
              u'Server PID: %d' % os.getpid()])
 
     @it.should("get diagnose info with an existing project file")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         reply = it.app.post(
             '/get_diagnose_info',
@@ -110,7 +110,7 @@ with such.A("hdlcc bottle app") as it:
                  u'Server PID: %d' % os.getpid()])
 
     @it.should("get diagnose info while still not found out the builder name")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         def _getServerByProjectFile(_):
             server = mock.MagicMock()
@@ -134,7 +134,7 @@ with such.A("hdlcc bottle app") as it:
                      u'Server PID: %d' % os.getpid()])
 
     @it.should("get diagnose info with a non existing project file")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         reply = it.app.post(
             '/get_diagnose_info',
@@ -147,7 +147,7 @@ with such.A("hdlcc bottle app") as it:
              u'Server PID: %d' % os.getpid()])
 
     @it.should("rebuild the project with directory cleanup")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         if not it.BUILDER_NAME:
             _logger.info("Test requires a builder")
@@ -238,7 +238,7 @@ with such.A("hdlcc bottle app") as it:
         step_05_check_messages_are_the_same(step_01_msgs)
 
     @it.should("rebuild the project without directory cleanup")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
             _logger.info("Test requires a builder, except fallback")
@@ -298,7 +298,7 @@ with such.A("hdlcc bottle app") as it:
         step_03_check_messages_are_the_same(step_01_msgs)
 
     @it.should("shutdown the server when requested")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         # Ensure the server is active
         reply = it.app.post('/get_diagnose_info',
@@ -326,7 +326,7 @@ with such.A("hdlcc bottle app") as it:
             shutil.rmtree(cache)
 
     @it.should("handle buffer visits without crashing")
-    @mock.patch('hdlcc.config_parser.hasVunit', lambda: False)
+    @mock.patch('hdlcc.config_parser.foundVunit', lambda: False)
     def test():
         if it.BUILDER_NAME not in ('ghdl', 'msim', 'xvhdl'):
             _logger.info("Test requires a builder, except fallback")

--- a/hdlcc/utils.py
+++ b/hdlcc/utils.py
@@ -151,7 +151,7 @@ def _isProcessRunningOnWindows(pid):
     """
     from ctypes import windll, c_ulong, sizeof, byref
 
-    #PSAPI.DLL
+    # PSAPI.DLL
     psapi = windll.psapi
 
     arr = c_ulong * 256
@@ -159,13 +159,13 @@ def _isProcessRunningOnWindows(pid):
     cb = sizeof(list_of_pids)  # pylint: disable=invalid-name
     cb_needed = c_ulong()
 
-    #Call Enumprocesses to get hold of process id's
+    # Call Enumprocesses to get hold of process id's
     psapi.EnumProcesses(byref(list_of_pids),
                         cb,
                         byref(cb_needed))
 
-    #Number of processes returned
-    number_of_pids = cb_needed.value/sizeof(c_ulong())
+    # Number of processes returned
+    number_of_pids = int(cb_needed.value/sizeof(c_ulong()))
 
     pid_list = [i for i in list_of_pids][:number_of_pids]
     return int(pid) in pid_list

--- a/run_tests.py
+++ b/run_tests.py
@@ -219,7 +219,7 @@ def _getDefaultTestByEnv(env):
     if env in ('msim', 'ghdl', 'xvhdl'):
         return ('hdlcc.tests.test_builders',
                 'hdlcc.tests.test_hdlcc_base',
-                'hdlcc.tests.test_persistency',
+                'hdlcc.tests.test_persistence',
                 'hdlcc.tests.test_server_handlers',
                 'hdlcc.tests.test_standalone')
     elif env == 'standalone':


### PR DESCRIPTION
* Server handlers accept 'content' field with the modified file content. This will be preferred instead of the actual file content
* Fixes on BaseParser's cache invalidation
* Refactoring the ConfigParser class
* Fixed issue with Python 3.5 under Windows
