### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email     = 'andre820@gmail.com',
     url              = 'https://github.com/suoto/hdlcc',
     license          = 'GPLv3',
-    packages         = ['hdlcc', 'hdlcc.builders'],
+    packages         = ['hdlcc', 'hdlcc.builders', 'hdlcc.parsers'],
     install_requires = ['argcomplete', 'argparse', 'prettytable',],
     cmdclass         = versioneer.get_cmdclass(),
     entry_points={


### PR DESCRIPTION
Add missing package 'hdlcc.parsers' in setup.py
Without this package in setup.py, got following error when trying to run hdlcc:
```
$ hdlcc -h
...
   File "/usr/local/lib/python2.7/dist-packages/hdlcc/hdlcc_base.py", line45, in <module>
    from hdlcc.parsers import VerilogParser, VhdlParser
ImportError: No module named parsers
```
Installation made with git clone + pip install